### PR TITLE
VP-3152: Update payment status in admin after checkout

### DIFF
--- a/Paypal.DirectPayments/Managers/PaypalDirectPaymentsPaymentMethod.cs
+++ b/Paypal.DirectPayments/Managers/PaypalDirectPaymentsPaymentMethod.cs
@@ -116,6 +116,8 @@ namespace Paypal.DirectPayments.Managers
             }
 
             retVal.NewPaymentStatus = context.Payment.PaymentStatus = newStatus;
+            context.Payment.Status = newStatus.ToString();
+
             return retVal;
         }
 


### PR DESCRIPTION
Despite the payment, the admin panel always displayed status "New" for payment via Paypal-DirectPayments. Now it's updating with new status of payment.
**Example with "Voided" status:**
![Voided](https://user-images.githubusercontent.com/22875828/84796870-73a2fb80-aff9-11ea-92ae-4bf4c318fc4e.png)
I can't show example with "Paid" status because my PayPal account is Russian, it's working only for merchants from some countries like US,UK,Canada
